### PR TITLE
Use the most recent `cfg_nag` version, currently 0.3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.4
 
 MAINTAINER thinkbot@outlook.de
 
-ENV VERSION=0.3.11
+ENV VERSION=0.3.16
 
 RUN gem install cfn-nag --version ${VERSION} --no-format-exec
 


### PR DESCRIPTION
Hello!

Thanks for creating this image.

We'd like to use the most recent version of `cfn_nag`, which is currently 0.3.16.

Fingers crossed, this PR does just that.